### PR TITLE
Fix dependency issue

### DIFF
--- a/modules/roles/manifests/mangodb.pp
+++ b/modules/roles/manifests/mangodb.pp
@@ -2,10 +2,7 @@ class roles::mangodb {
     package { 'epel-release': ensure => present } ->
     package { 'python-pip':   ensure => present } ->
     package { 'python-devel': ensure => present } ->
-    package { 'gevent':
-        ensure   => present,
-        provider => "pip",
-    } ->
+    package { 'python-gevent': ensure => present } ->
     exec { 'install_mangodb':
         command  => "curl -o /usr/local/bin/mangodb https://github.com/dcramer/mangodb/raw/master/server.py",
         path     => "/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin",


### PR DESCRIPTION
pip was failing to pull in all dependencies on my build test.
`
==> default: Error: /Stage[main]/Roles::Mangodb/Package[gevent]/ensure: change from absent to present failed: Execution of '/bin/pip install -q gevent' returned 1: Command "/usr/bin/python -c "import setuptools, tokenize;__file__='/tmp/pip-build-OeGKNv/greenlet/setup.py';exec(compile(getattr(tokenize, 'open', open)(__file__).read().replace('\r\n', '\n'), __file__, 'exec'))" install --record /tmp/pip-3UJtQP-record/install-record.txt --single-version-externally-managed --compile" failed with error code 1 in /tmp/pip-build-OeGKNv/greenlet
==> default: Warning: /Stage[main]/Roles::Mangodb/Exec[install_mangodb]: Skipping because of failed dependencies
`

Second build after destroying VM:
`
==> default: Running Puppet with default.pp...
==> default: Notice: Compiled catalog for centos7 in environment production in 1.22 seconds
==> default: Notice: /Stage[main]/Roles::Mangodb/Package[epel-release]/ensure: created
==> default: Notice: /Stage[main]/Roles::Mangodb/Package[python-pip]/ensure: created
==> default: Notice: /Stage[main]/Roles::Mangodb/Package[python-devel]/ensure: created
==> default: Notice: /Stage[main]/Roles::Mangodb/Package[python-gevent]/ensure: created
==> default: Notice: /Stage[main]/Roles::Mangodb/Exec[install_mangodb]/returns: executed successfully
==> default: Notice: /Stage[main]/Ntp::Install/Package[ntp]/ensure: created
==> default: Notice: /Stage[main]/Ntp::Config/File[/etc/ntp.conf]/content: content changed '{md5}dc9e5754ad2bb6f6c32b954c04431d0a' to '{md5}30f979758f796a5b533afb77dc34b0c4'
==> default: Notice: /Stage[main]/Ntp::Service/Service[ntp]/ensure: ensure changed 'stopped' to 'running'
==> default: Notice: Finished catalog run in 30.32 seconds
`

Also, wtf is mangodb
